### PR TITLE
Add index for elastic search to common library

### DIFF
--- a/amundsen_common/elastic_search/elastic_search_index.py
+++ b/amundsen_common/elastic_search/elastic_search_index.py
@@ -1,0 +1,90 @@
+import textwrap
+
+# Specifying default mapping for elasticsearch index
+# Documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
+# Setting type to "text" for all fields that would be used in search
+# Using Simple Analyzer to convert all text into search terms
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-simple-analyzer.html
+# Standard Analyzer is used for all text fields that don't explicitly specify an analyzer
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html
+DEFAULT_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
+    """
+    {
+    "mappings":{
+        "table":{
+          "properties": {
+            "name": {
+              "type":"text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "schema": {
+              "type":"text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "display_name": {
+              "type": "keyword"
+            },
+            "last_updated_timestamp": {
+              "type": "date",
+              "format": "epoch_second"
+            },
+            "description": {
+              "type": "text",
+              "analyzer": "simple"
+            },
+            "column_names": {
+              "type":"text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "column_descriptions": {
+              "type": "text",
+              "analyzer": "simple"
+            },
+            "tags": {
+              "type": "keyword"
+            },
+            "badges": {
+              "type": "keyword"
+            },
+            "cluster": {
+              "type": "text"
+            },
+            "database": {
+              "type": "text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "key": {
+              "type": "keyword"
+            },
+            "total_usage":{
+              "type": "long"
+            },
+            "unique_usage": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+    """
+)

--- a/amundsen_common/elastic_search/index_map.py
+++ b/amundsen_common/elastic_search/index_map.py
@@ -7,7 +7,7 @@ import textwrap
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-simple-analyzer.html
 # Standard Analyzer is used for all text fields that don't explicitly specify an analyzer
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html
-DEFAULT_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
+TABLE_INDEX_MAP = textwrap.dedent(
     """
     {
     "mappings":{
@@ -88,3 +88,58 @@ DEFAULT_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
     }
     """
 )
+
+USER_INDEX_MAP = textwrap.dedent("""
+{
+"mappings":{
+    "user":{
+      "properties": {
+        "email": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "first_name": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "last_name": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "name": {
+          "type":"text",
+          "analyzer": "simple",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "total_read":{
+          "type": "long"
+        },
+        "total_own": {
+          "type": "long"
+        },
+        "total_follow": {
+          "type": "long"
+        }
+      }
+    }
+  }
+}""")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='amundsen-common',
-    version='0.2.2',
+    version='0.2.3',
     description='Common code library for Amundsen',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Summary of Changes

Moves the elastic search index map into common library so it can be used by both search + databuilder. 

### Tests
No tests added/changed as only a constant has been added. 

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
