### PR TITLE
feat: added resource_reports into Table model

### DIFF
--- a/amundsen_common/models/table.py
+++ b/amundsen_common/models/table.py
@@ -99,6 +99,17 @@ class SourceSchema(AttrsSchema):
         target = Source
         register_as_scheme = True
 
+@attr.s(auto_attribs=True, kw_only=True)
+class TableReport:
+    name: str
+    url: str
+
+
+class TableReportSchema(AttrsSchema):
+    class Meta:
+        target = TableReport
+        register_as_scheme = True
+
 
 # this is a temporary hack to satisfy mypy. Once https://github.com/python/mypy/issues/6136 is resolved, use
 # `attr.converters.default_if_none(default=False)`
@@ -132,6 +143,7 @@ class Table:
     owners: List[User] = []
     watermarks: List[Watermark] = []
     table_writer: Optional[Application] = None
+    table_reports: Optional[List[TableReport]] = None
     last_updated_timestamp: Optional[int] = None
     source: Optional[Source] = None
     is_view: Optional[bool] = attr.ib(default=None, converter=default_if_none)

--- a/amundsen_common/models/table.py
+++ b/amundsen_common/models/table.py
@@ -100,14 +100,14 @@ class SourceSchema(AttrsSchema):
         register_as_scheme = True
 
 @attr.s(auto_attribs=True, kw_only=True)
-class TableReport:
+class ResourceReport:
     name: str
     url: str
 
 
-class TableReportSchema(AttrsSchema):
+class ResourceReportSchema(AttrsSchema):
     class Meta:
-        target = TableReport
+        target = ResourceReport
         register_as_scheme = True
 
 
@@ -143,7 +143,7 @@ class Table:
     owners: List[User] = []
     watermarks: List[Watermark] = []
     table_writer: Optional[Application] = None
-    table_reports: Optional[List[TableReport]] = None
+    resource_reports: Optional[List[ResourceReport]] = None
     last_updated_timestamp: Optional[int] = None
     source: Optional[Source] = None
     is_view: Optional[bool] = attr.ib(default=None, converter=default_if_none)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask==1.1.1
 marshmallow==2.15.3
 marshmallow-annotations==2.4.0
 mypy==0.720
-pytest
+pytest>=4.6
 pytest-cov
 pytest-mock
 mock


### PR DESCRIPTION
### Summary of Changes

Added `resource_reports ` into Table model to support integration with tools generating static HTML reports, such as [popmon](https://github.com/ing-bank/popmon), [pandas-profiling]( https://github.com/pandas-profiling/pandas-profiling) or [great_expectations](https://github.com/great-expectations/great_expectations).

additionally, there were conflicts with pytest version used in ci-pipeline,  version had been changed to >=4.6 so that ci-test could be completed

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x ] PR includes a summary of changes. 
- [x ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ x] PR passes `make test`
